### PR TITLE
Improved support for task chaining

### DIFF
--- a/src/main/groovy/org/whitesource/gradle/tasks/CollectProjectInfoTask.groovy
+++ b/src/main/groovy/org/whitesource/gradle/tasks/CollectProjectInfoTask.groovy
@@ -38,7 +38,7 @@ class CollectProjectInfoTask extends DefaultTask {
             projectName = project.name
         }
 
-        logger.lifecycle("Processing project ${project.name}")
+        logger.info("Processing project ${project.name}")
         def projectInfo = new AgentProjectInfo()
         projectInfo.setCoordinates(new Coordinates(null, projectName, null))
         if (project.parent) {
@@ -88,8 +88,8 @@ class CollectProjectInfoTask extends DefaultTask {
                 def resolvedDependency = (ResolvedDependency) dependency
                 def info = getDependencyInfo(resolvedDependency, addedSha1s)
                 if (info.getGroupId() != null || info.getArtifactId() != null || info.getVersion() != null) {
-                    logger.lifecycle("CollectProjectInfoTask:CollectProjectInfos - info.groupId = " + info.getGroupId());
-                    logger.lifecycle("CollectProjectInfoTask:CollectProjectInfos - projectInfo.getDependencies() = " + projectInfo.getDependencies());
+                    logger.debug("CollectProjectInfoTask:CollectProjectInfos - info.groupId = " + info.getGroupId());
+                    logger.debug("CollectProjectInfoTask:CollectProjectInfos - projectInfo.getDependencies() = " + projectInfo.getDependencies());
                     projectInfo.getDependencies().add(info)
                 }
             }
@@ -103,20 +103,20 @@ class CollectProjectInfoTask extends DefaultTask {
                     dependencyInfo.setSha1(sha1)
                     dependencyInfo.setDependencyType(DependencyType.GRADLE)
                     projectInfo.getDependencies().add(dependencyInfo)
-                    logger.lifecycle("CollectProjectInfoTask:CollectProjectInfos - addedSha1s = " + addedSha1s);
-                    logger.lifecycle("CollectProjectInfoTask:CollectProjectInfos - sha1 = " + sha1);
+                    logger.debug("CollectProjectInfoTask:CollectProjectInfos - addedSha1s = " + addedSha1s);
+                    logger.debug("CollectProjectInfoTask:CollectProjectInfos - sha1 = " + sha1);
                     addedSha1s.add(sha1)
                 }
             }
         }
 
-        logger.lifecycle("CollectProjectInfoTask:CollectProjectInfos - project.projectInfos = " + project.projectInfos);
+        logger.debug("CollectProjectInfoTask:CollectProjectInfos - project.projectInfos = " + project.projectInfos);
         project.projectInfos.add(projectInfo)
     }
 
     def getDependencyInfo(ResolvedDependency dependency, addedSha1s) {
         def dependencyInfo = new DependencyInfo()
-        logger.lifecycle("CollectProjectInfoTask:getDependencyInfo - dependency.getAllModuleArtifacts() = " + dependency.getAllModuleArtifacts());
+        logger.debug("CollectProjectInfoTask:getDependencyInfo - dependency.getAllModuleArtifacts() = " + dependency.getAllModuleArtifacts());
         def artifact = dependency.getAllModuleArtifacts()[0]
         if (artifact != null) {
             def file = artifact.getFile()
@@ -126,14 +126,14 @@ class CollectProjectInfoTask extends DefaultTask {
                 dependencyInfo.setArtifactId(dependency.getModuleName())
                 dependencyInfo.setVersion(dependency.getModuleVersion())
                 dependencyInfo.setSha1(sha1)
-                logger.lifecycle("CollectProjectInfoTask:getDependencyInfo - addedSha1s = " + addedSha1s);
-                logger.lifecycle("CollectProjectInfoTask:getDependencyInfo - sha1 = " + sha1);
+                logger.debug("CollectProjectInfoTask:getDependencyInfo - addedSha1s = " + addedSha1s);
+                logger.debug("CollectProjectInfoTask:getDependencyInfo - sha1 = " + sha1);
                 addedSha1s.add(sha1)
                 dependency.getChildren().each {
                     def info = getDependencyInfo(it, addedSha1s)
                     if (info.getSha1() != null) {
-                        logger.lifecycle("CollectProjectInfoTask:getDependencyInfo - dependencyInfo.getChildren() = " + dependencyInfo.getChildren());
-                        logger.lifecycle("CollectProjectInfoTask:getDependencyInfo - info = " + info);
+                        logger.debug("CollectProjectInfoTask:getDependencyInfo - dependencyInfo.getChildren() = " + dependencyInfo.getChildren());
+                        logger.debug("CollectProjectInfoTask:getDependencyInfo - info = " + info);
                         dependencyInfo.getChildren().add(info)
                     }
                 }

--- a/src/main/groovy/org/whitesource/gradle/tasks/UpdateWhitesourceInventoryTask.groovy
+++ b/src/main/groovy/org/whitesource/gradle/tasks/UpdateWhitesourceInventoryTask.groovy
@@ -54,7 +54,7 @@ class UpdateWhitesourceInventoryTask extends DefaultTask {
 
             if (!gotPolicyRejections || wssConfig.forceUpdate) {
                 if (gotPolicyRejections) {
-                    logger.lifecycle('The forceUpdate flag is set to true. Updating White Source despite policy violations')
+                    logger.info('The forceUpdate flag is set to true. Updating White Source despite policy violations')
                 }
                 sendUpdate(orgToken)
             }
@@ -104,59 +104,59 @@ class UpdateWhitesourceInventoryTask extends DefaultTask {
     }
 
     private boolean checkPolicies(String orgToken) {
-        logger.lifecycle('Checking policies...')
+        logger.info('Checking policies...')
         CheckPolicyComplianceResult result = service.checkPolicyCompliance(orgToken, wssConfig.productName, wssConfig.productVersion, project.projectInfos, wssConfig.forceCheckAllDependencies)
         if (wssConfig.reportsDirectory.exists() || wssConfig.reportsDirectory.mkdirs()) {
-            logger.lifecycle('Generating policy check report')
+            logger.info('Generating policy check report')
             PolicyCheckReport report = new PolicyCheckReport(result)
             report.generate(wssConfig.reportsDirectory, false)
         } else {
-            logger.lifecycle("Failed to create outputdirectory ${wssConfig.reportsDirectory}. Skipping policies check report.")
+            logger.info("Failed to create outputdirectory ${wssConfig.reportsDirectory}. Skipping policies check report.")
         }
 
         if (result.hasRejections()) {
             logger.error("Some dependencies were rejected by the organization's policies. See policy check report at ${wssConfig.reportsDirectory}")
         } else {
-            logger.lifecycle("All dependencies conform with the organization's policies.")
+            logger.info("All dependencies conform with the organization's policies.")
         }
 
         return result.hasRejections()
     }
 
     private void sendUpdate(orgToken) {
-        logger.lifecycle('Sending updates to White Source')
+        logger.info('Sending updates to White Source')
         UpdateInventoryResult result = service.update(orgToken, wssConfig.requesterEmail, wssConfig.productName, wssConfig.productVersion, project.projectInfos)
         logResult(result)
     }
 
     private void logResult(UpdateInventoryResult result) {
-        logger.lifecycle("Inventory update results for ${result.getOrganization()}")
+        logger.info("Inventory update results for ${result.getOrganization()}")
 
         // newly created projects
         Collection<String> createdProjects = result.getCreatedProjects()
         if (createdProjects.isEmpty()) {
-            logger.lifecycle('No new projects found.')
+            logger.info('No new projects found.')
         } else {
-            logger.lifecycle('Newly created projects:')
+            logger.info('Newly created projects:')
             for (String projectName : createdProjects) {
-                logger.lifecycle("\t${projectName}")
+                logger.info("\t${projectName}")
             }
         }
 
         // updated projects
         Collection<String> updatedProjects = result.getUpdatedProjects()
         if (updatedProjects.isEmpty()) {
-            logger.lifecycle('No projects were updated.')
+            logger.info('No projects were updated.')
         } else {
-            logger.lifecycle('Updated projects:')
+            logger.info('Updated projects:')
             for (String projectName : updatedProjects) {
-                logger.lifecycle("\t${projectName}")
+                logger.info("\t${projectName}")
             }
         }
 
         String requestToken = result.getRequestToken();
         if (StringUtils.isNotBlank(requestToken)) {
-            logger.lifecycle("Support Token: {}", requestToken);
+            logger.info("Support Token: {}", requestToken);
         }
     }
 


### PR DESCRIPTION
This pull request blends a couple of different improvements:

1. Move the task declaration out of the `afterEvaluate` block to easy task chaining between custom build file tasks and WhiteSource plugin tasks
> The primary driver of this was to support integration with other plugins, such as [CloudFoundry](https://github.com/pivotalservices/ya-cf-app-gradle-plugin). As of 18.3.2, a top-level statement of `cf-push.dependsOn updateWhitesource` will fail.

2. Update log levels for `lifecycle` logging statements support quieter output in rich consoles.