### PR TITLE
Enable multi-project aggregation

### DIFF
--- a/src/main/groovy/org/whitesource/gradle/tasks/CollectProjectInfoTask.groovy
+++ b/src/main/groovy/org/whitesource/gradle/tasks/CollectProjectInfoTask.groovy
@@ -51,8 +51,13 @@ class CollectProjectInfoTask extends DefaultTask {
             projectInfo.setProjectToken(wssConfig.projectToken)
         }
 
-        def configurationsToInclude = project.configurations.findAll { thisProjectConfiguration ->
-            thisProjectConfiguration.name in wssConfig.includedConfigurationNames || thisProjectConfiguration.name in wssConfig.includedConfigurations*.name
+        def configurationsToInclude
+        if (wssConfig.includedConfigurations.isEmpty()) {
+            configurationsToInclude = project.configurations.findAll { thisProjectConfiguration ->
+                thisProjectConfiguration.name in wssConfig.includedConfigurationNames
+            }
+        } else {
+            configurationsToInclude = wssConfig.includedConfigurations        
         }
 
         def addedSha1s = new HashSet<String>()


### PR DESCRIPTION
The current version of the plugin does not support direct references to included configurations. Rather, the included `Configuration` references are used solely for the purpose of extracting configuration names for filtering within the scope of a single (sub)project.

By leveraging the `Configuration` references themselves, the existing Gradle plugin could support cross-project and/or multi-project aggregation in a similar way to the Maven plugin.

Below is a minimalist DSL sample that demonstrates how this change could support the aggregation of libraries across all subproject modules.

```
evaluationDependsOnChildren()

whitesource {
    orgToken = '<your organization token>' // replace with you organization token

    includeProject rootProject
    afterEvaluate {  
        includeConfigurations subprojects.collect { it.configurations.runtime }
    }
}
```